### PR TITLE
Updated primary branch to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: build
 
 on:
   pull_request:
-    branches: [ develop ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: release
+name: deploy
 
 on:
   push:

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -46,7 +46,7 @@ module.exports = {
           routeBasePath: '/',
           sidebarPath: require.resolve('./sidebars.js'),
           editUrl:
-            'https://github.com/smatechnologies/opcon-docs/blob/develop',
+            'https://github.com/smatechnologies/opcon-docs/blob/main',
           lastVersion: 'current',
           versions: {
             'current': {


### PR DESCRIPTION
With trunk-based development, no longer required to batch a 'release'.  CD each time commits to main.

Updated PR requests to assume a target of main, rather than develop.

Updated Docusaurus reference so the 'Edit this page' links properly drop users off at the main branch.