### PR TITLE
Updated PR build action to trigger on develop pull request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,9 @@ name: build
 
 on:
   pull_request:
-    branches: [ main ]
+    branches:
+      - 'main'
+      - 'develop' 
 
 jobs:
   build:


### PR DESCRIPTION
This was done in preparation for creating a develop branch. 

'develop' is intended to hold documentation that is part of vNext and has not yet been released.

New feature release automation should target develop and rebase changes onto main.