### PR TITLE
Removing duplicate master jobs link

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -475,7 +475,6 @@ module.exports = {
                             "Files/UI/Solution-Manager/Library/MasterJobs/Viewing-And-Updating-Master-Jobs/JobTaskDetails/Windows-Job-Details",
                           ],
                         },
-                        "Files/UI/Solution-Manager/Library/MasterJobs/Viewing-And-Updating-Master-Jobs/Accessing-Master-Jobs",
                         "Files/UI/Solution-Manager/Library/MasterJobs/Viewing-And-Updating-Master-Jobs/Viewing-And-Updating-General-Info",
                         "Files/UI/Solution-Manager/Library/MasterJobs/Viewing-And-Updating-Master-Jobs/Viewing-And-Updating-Documentation",
                         "Files/UI/Solution-Manager/Library/MasterJobs/Viewing-And-Updating-Master-Jobs/Viewing-And-Updating-Tags",


### PR DESCRIPTION
We already have Accessing Master Jobs doc link on the side bar, removing the duplicate.

![image](https://user-images.githubusercontent.com/2902102/228094105-b4556edf-b5df-416c-849a-588f77eb79af.png)
