### PR TITLE
Release notes 23.0.2

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ slug: "/"
 
 OpCon (Operations Console Cross-Platform Scheduler) is an enterprise-wide, heterogeneous workflow automation and orchestration platform.
 
-The current release is **OpCon 23.0.1**.
+The current release is **OpCon 23.0.0**.
 
 The following sections contain more information:
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -4,24 +4,6 @@ sidebar_label: "Release Notes"
 
 # OpCon Release Notes
 
-## OpCon 23.0.1
-
-**NOTE**: Verify/Upgrade these components if applicable: **ServiceNow** Connector – 21.4 or higher, **WebServices** Connector – 21.2 or higher, **Deploy** – 22.4 or higher
-
-2024 March
-
-#### Solution Manager
-
-:white_check_mark: **OPCON-23054**: Fixed an issue when adding jobs to a daily schedule, the schedule and job names in results dialog appeared in lowercase.
-
-:white_check_mark: **OPCON-23207**: Fixed issue where all nodes will have red borders when a schedule is first loaded onto the workflow. This change removes the red border from these nodes and only nodes on position (0, 0) will have red borders.
-
-#### ImpEx2 Web Service
-
-:white_check_mark: **OPCON-23055**: Fixed a problem during schedule deployment removing schedule named instances if the new version of the schedule no longer has any defined schedule named instances.
-
-:white_check_mark: **OPCON-23091**: Fixed an issue during deployment where the global property value was erroneously mixed up when there were other property names with a similar pattern.
-
 ## OpCon 23.0.0
 
 **NOTE**: Verify/Upgrade these components if applicable: **ServiceNow** Connector – 21.4 or higher, **WebServices** Connector – 21.2 or higher, **Deploy** – 22.4 or higher

--- a/versioned_docs/version-23.0/index.md
+++ b/versioned_docs/version-23.0/index.md
@@ -6,7 +6,7 @@ slug: "/"
 
 OpCon (Operations Console Cross-Platform Scheduler) is an enterprise-wide, heterogeneous workflow automation and orchestration platform.
 
-The current release is **OpCon 23.0.1**.
+The current release is **OpCon 23.0.2**.
 
 The following sections contain more information:
 

--- a/versioned_docs/version-23.0/release-notes.md
+++ b/versioned_docs/version-23.0/release-notes.md
@@ -4,6 +4,42 @@ sidebar_label: "Release Notes"
 
 # OpCon Release Notes
 
+## OpCon 23.0.2
+
+**NOTE**: Verify/Upgrade these components if applicable: **ServiceNow** Connector – 21.4 or higher, **WebServices** Connector – 21.2 or higher, **Deploy** – 22.4 or higher
+
+2024 April
+
+#### Installation
+
+:white_check_mark: **OPCON-23104**: Modified SMADB_Backup script from having WITH NOINIT to having WITH INIT and SMADB_TLog_Backup script from having WITH INIT to having WITH NOINIT.
+
+#### Solution Manager
+
+:white_check_mark: **OPCON-22994**: Fixed an issue where named instance schedules could not be created when Solution Manager was in French.
+
+:white_check_mark: **OPCON-23015**: Fixed an issue where the Save button in daily jobs definition page was enabled without any changes.
+
+:white_check_mark: **OPCON-23065**: Fixed an issue where users with privilege "Modify Jobs in Master Schedules" could not save changes to master jobs.
+
+:white_check_mark: **OPCON-23072**: Fixed an issue where PERT diagram breadcrumbs for sub-schedules were missing.
+
+:white_check_mark: **OPCON-23106**: Resolved an issue where the parameter "Requires XML Escape Sequences" for some Agents was incorrect.
+
+:white_check_mark: **OPCON-23107**: Resolved a bug that blocked tab navigation on the Access Management page when the interface was set to French.
+
+:white_check_mark: **OPCON-23108**: Fixed an issue where Users and Roles were not correctly displayed in a Firefox browser.
+
+:white_check_mark: **OPCON-23247**: Fixed Master Job validation for IBMi Spool File values.
+
+:white_check_mark: **OPCON-23248**: Fixed an issue causing users to be unable to remove frequencies from schedules.
+
+:white_check_mark: **OPCON-23251**: Fixed an issue where the date user input was incorrect when time zone was set to Central European Time.
+
+#### REST API
+
+:white_check_mark: **OPCON-22270**: Fixed an issue where retrieving data in Schedule and Job History Report was timing out.
+
 ## OpCon 23.0.1
 
 **NOTE**: Verify/Upgrade these components if applicable: **ServiceNow** Connector – 21.4 or higher, **WebServices** Connector – 21.2 or higher, **Deploy** – 22.4 or higher

--- a/versioned_docs/version-23.0/release-notes.md
+++ b/versioned_docs/version-23.0/release-notes.md
@@ -26,15 +26,15 @@ sidebar_label: "Release Notes"
 
 :white_check_mark: **OPCON-23106**: Resolved an issue where the parameter "Requires XML Escape Sequences" for some Agents was incorrect.
 
-:white_check_mark: **OPCON-23107**: Resolved a bug that blocked tab navigation on the Access Management page when the interface was set to French.
+:white_check_mark: **OPCON-23107**: Resolved an issue that blocked tab navigation on the Access Management page when the interface was set to French.
 
 :white_check_mark: **OPCON-23108**: Fixed an issue where Users and Roles were not correctly displayed in a Firefox browser.
 
-:white_check_mark: **OPCON-23247**: Fixed Master Job validation for IBMi Spool File values.
+:white_check_mark: **OPCON-23247**: Fixed an issue that caused a runtime error when saving IBMi Spool File values in Master Jobs.
 
-:white_check_mark: **OPCON-23248**: Fixed an issue causing users to be unable to remove frequencies from schedules.
+:white_check_mark: **OPCON-23248**: Fixed an issue where users were unable to remove frequencies from schedules.
 
-:white_check_mark: **OPCON-23251**: Fixed an issue where the date user input was incorrect when time zone was set to Central European Time.
+:white_check_mark: **OPCON-23251**: Fixed an issue where the resolved value for the date user input in Self-Service was incorrect when the time zone was set to Central European Time.
 
 #### REST API
 


### PR DESCRIPTION
- Changed current version in ...\opcon-docs\docs\index.md from 23.0.1 to 23.0.0.
- Removed release notes for 23.0.1 from ...\opcon-docs\docs\release-notes.md.
- Changed current version in ...\opcon-docs\versioned-docs\version-23.0\index.md from 23.0.1 to 23.0.2.
- Added release notes for 23.0.2 to ...\opcon-docs\versioned-docs\version-23.0\release-notes.md.