### PR TITLE
Release notes for 22.0.14

### DIFF
--- a/versioned_docs/version-22.0/index.md
+++ b/versioned_docs/version-22.0/index.md
@@ -6,7 +6,7 @@ slug: "/"
 
 OpCon (Operations Console Cross-Platform Scheduler) is an enterprise-wide, heterogeneous workflow automation and orchestration platform.
 
-The current release is **OpCon 22.0.13**.
+The current release is **OpCon 22.0.14**.
 
 The following sections contain more information:
 

--- a/versioned_docs/version-22.0/release-notes.md
+++ b/versioned_docs/version-22.0/release-notes.md
@@ -4,6 +4,16 @@ sidebar_label: "Release Notes"
 
 # OpCon Release Notes
 
+## OpCon 22.0.14
+
+2024 April
+
+#### Solution Manager
+
+:white_check_mark: **OPCON-22994**: Fixed an issue where named instance schedules could not be created when Solution Manager was in French.
+
+:white_check_mark: **OPCON-23015**: Fixed an issue where the Save button in daily jobs definition page was enabled without any changes.
+
 ## OpCon 22.0.13
 
 2024 March


### PR DESCRIPTION
- Changed current version in ...\opcon-docs\versioned-docs\version-22.0\index.md from 22.0.13 to 22.0.14.
- Added release notes for 22.0.14 to ...\opcon-docs\versioned-docs\version-22.0\release-notes.md.