### PR TITLE
Fixed errors in release notes

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -129,7 +129,7 @@ Customers benefit from improved resilience, faster recovery from network issues,
 :white_check_mark: **OC-4593: REST API Security Hardening**
 A path traversal vulnerability in the Logs endpoint has been addressed, strengthening overall API security.
 
-:open_file_folder: **OC-5089: Updated API Documentation**
+:white_check_mark: **OC-5089: Updated API Documentation**
 Job History API documentation has been updated to reflect current behavior and improve developer usability.
 
 ### Why This Matters

--- a/versioned_docs/version-26.0/release-notes.md
+++ b/versioned_docs/version-26.0/release-notes.md
@@ -127,7 +127,7 @@ Customers benefit from improved resilience, faster recovery from network issues,
 :white_check_mark: **OC-4593: REST API Security Hardening**
 A path traversal vulnerability in the Logs endpoint has been addressed, strengthening overall API security.
 
-:open_file_folder: **OC-5089: Updated API Documentation**
+:white_check_mark: **OC-5089: Updated API Documentation**
 Job History API documentation has been updated to reflect current behavior and improve developer usability.
 
 ### Why This Matters

--- a/versioned_sidebars/version-26.0-sidebars.json
+++ b/versioned_sidebars/version-26.0-sidebars.json
@@ -922,7 +922,7 @@
     {
       "type": "link",
       "label": "REST API Docs",
-      "href": "https://help.smatechnologies.com/opcon/core/api/25-1.html"
+      "href": "https://help.smatechnologies.com/opcon/core/api/26-0.html"
     }
   ]
 }


### PR DESCRIPTION
- Corrected the icon in the release notes for cloud and on-prem 26.0.1.
- Corrected the version in the API link.