### PR TITLE
oc-5539: Relays and NetComs feature

### DIFF
--- a/docs/Files/UI/Solution-Manager/Library/Relays/Managing-Relays.md
+++ b/docs/Files/UI/Solution-Manager/Library/Relays/Managing-Relays.md
@@ -1,0 +1,104 @@
+---
+title: Managing relays
+description: "Monitor relay and NetCom status, restart relays, upgrade relay versions, view logs, and perform manual failover in Solution Manager."
+tags:
+  - Procedural
+  - System Administrator
+  - Automation Engineer
+  - Solution Manager
+---
+
+# Managing relays
+
+Use the **Relays / NetComs** page in Solution Manager to monitor communication status and perform management operations on relays and to view NetComs. For background on relay architecture and terminology, see [Relays overview](Relays-Overview.md).
+
+## Viewing relay and NetCom status
+
+The **Relays / NetComs** page displays the current status of all registered relays and NetComs. Relays appear in the upper grid and NetComs appear in the lower grid.
+
+To view relay and NetCom status, complete the following steps:
+
+1. Go to **Library** > **Relays / NetComs**. The Relays / NetComs page is displayed with both grids.
+2. (Optional) In either grid, use the **Status** filter to show only relays or NetComs with a specific status.
+3. (Optional) In either grid, enter a name in the search field to find a specific relay or NetCom.
+
+For a description of each column, see [Relays reference](Relays-Reference.md).
+
+## Restarting a relay
+
+You can restart a relay that is in Standby or Stopped status. After you start the restart, OpCon polls for the relay to return to Communicating status.
+
+:::note
+You must have the OCADM role to restart a relay.
+:::
+
+To restart a relay, complete the following steps:
+
+1. Go to **Library** > **Relays / NetComs**.
+2. In the **Relays** grid, select the relay you want to restart. The relay must have a status of Standby or Stopped.
+3. Select the **Restart** button. OpCon sends the restart command to the relay.
+4. Wait for the relay status to change to Communicating. The restart operation times out after 2 minutes if the relay does not respond.
+
+## Upgrading a relay
+
+You can upgrade a relay to a newer version when an upgrade is available.
+
+:::note
+You must have the OCADM role to upgrade a relay.
+:::
+
+To upgrade a relay, complete the following steps:
+
+1. Go to **Library** > **Relays / NetComs**.
+2. In the **Relays** grid, select the relay you want to upgrade.
+3. Select the **Upgrade** button. The Upgrade Relay dialog is displayed with the current version and a list of available versions.
+4. From the **Select Relay** list, select the version you want to install.
+5. Select the **Save** button. The upgrade begins and the dialog closes.
+
+## Viewing relay logs
+
+You can view relay logs to troubleshoot communication issues. The Relay Logs dialog provides access to three log files.
+
+To view relay logs, complete the following steps:
+
+1. Go to **Library** > **Relays / NetComs**.
+2. In the **Relays** grid, select the relay whose logs you want to view.
+3. Select the **Logs** button. The Relay Logs dialog is displayed.
+4. Select the tab for the log file you want to view:
+   - **SMANetComRelay.log** — Main relay log with configuration and communication information
+   - **SMANetComRelayAPI.log** — NetCom API communication log
+   - **SMANetComTrace.log** — Detailed trace log with TCP/IP and socket connection information
+5. (Optional) Select the **Refresh** button to reload the log content.
+6. (Optional) Select the **Export** button to download the log file.
+7. Select the **Cancel** button to close the dialog.
+
+## Performing a manual relay failover
+
+A manual failover transitions agent communication from the primary relay to a standby relay. Use this procedure when the primary relay needs to be taken offline for maintenance or when you need to redirect communication to a different machine.
+
+:::caution
+Once the failover process starts, it must complete the full transition. This process may take a few minutes.
+:::
+
+:::note
+You must have the OCADM role to perform a failover. The **Choose Failover** button is available only when a Primary relay with a status of Communicating is selected and a Standby relay with the same name exists. For the full list of requirements, see [Failover requirements](Relays-Reference.md#failover-requirements).
+:::
+
+To perform a manual relay failover, complete the following steps:
+
+1. Go to **Library** > **Relays / NetComs**.
+2. In the **Relays** grid, select the Primary relay you want to fail over from.
+3. Select the **Choose Failover** button. The Relay Failover dialog is displayed with the primary relay name and machine pre-populated.
+4. In the **Failover Relay** section, select the target machine from the **Machine** list.
+5. (Optional) In the **Failover Reason** field, enter a reason for the failover.
+6. Note: The transition process on the right side of the dialog shows a static list of each of the six steps of the failover progress. For a description of each step, see [Failover transition steps](Relays-Reference.md#failover-transition-steps).
+7. Select the **Connect** button. The dialog closes and the failover transition begins.
+8. When the transition completes successfully, a confirmation message is displayed. Select the button to close the dialog.
+
+If the failover fails or times out, an error message is displayed. Review the relay logs to investigate the issue.
+
+## Related topics
+
+- [Relays overview](Relays-Overview.md)
+- [Relays reference](Relays-Reference.md)
+- [SMA Network Communications Module](../../../../../server-programs/network-communications.md)

--- a/docs/Files/UI/Solution-Manager/Library/Relays/Managing-Relays.md
+++ b/docs/Files/UI/Solution-Manager/Library/Relays/Managing-Relays.md
@@ -26,7 +26,7 @@ For a description of each column, see [Relays reference](Relays-Reference.md).
 
 ## Restarting a relay
 
-You can restart a relay that is in Standby or Stopped status. After you start the restart, OpCon polls for the relay to return to Communicating status.
+You can restart a relay that is in Communicating or Standby status. After you initiate the restart, OpCon polls for the relay to return to Communicating/Standby status.
 
 :::note
 You must have the OCADM role to restart a relay.
@@ -35,9 +35,9 @@ You must have the OCADM role to restart a relay.
 To restart a relay, complete the following steps:
 
 1. Go to **Library** > **Relays / NetComs**.
-2. In the **Relays** grid, select the relay you want to restart. The relay must have a status of Standby or Stopped.
+2. In the **Relays** grid, select the relay you want to restart. The relay must have a status of Communicating or Standby.
 3. Select the **Restart** button. OpCon sends the restart command to the relay.
-4. Wait for the relay status to change to Communicating. The restart operation times out after 2 minutes if the relay does not respond.
+4. Wait for the relay status to change to Communicating or Standby. The restart operation times out after 2 minutes if the relay does not respond.
 
 ## Upgrading a relay
 
@@ -50,7 +50,7 @@ You must have the OCADM role to upgrade a relay.
 To upgrade a relay, complete the following steps:
 
 1. Go to **Library** > **Relays / NetComs**.
-2. In the **Relays** grid, select the relay you want to upgrade.
+2. In the **Relays** grid, select the relay you want to upgrade. The **Upgrade** button is only enabled if the relay is in Communicating or Standby status and an upgrade is available for the relay version.
 3. Select the **Upgrade** button. The Upgrade Relay dialog is displayed with the current version and a list of available versions.
 4. From the **Select Relay** list, select the version you want to install.
 5. Select the **Save** button. The upgrade begins and the dialog closes.
@@ -62,7 +62,7 @@ You can view relay logs to troubleshoot communication issues. The Relay Logs dia
 To view relay logs, complete the following steps:
 
 1. Go to **Library** > **Relays / NetComs**.
-2. In the **Relays** grid, select the relay whose logs you want to view.
+2. In the **Relays** grid, select the relay whose logs you want to view. The **Logs** button is only enabled if the relay is in Communicating or Standby status.
 3. Select the **Logs** button. The Relay Logs dialog is displayed.
 4. Select the tab for the log file you want to view:
    - **SMANetComRelay.log** — Main relay log with configuration and communication information

--- a/docs/Files/UI/Solution-Manager/Library/Relays/Relays-Overview.md
+++ b/docs/Files/UI/Solution-Manager/Library/Relays/Relays-Overview.md
@@ -14,9 +14,9 @@ Relays and NetComs manage communication between the OpCon server and agents acro
 
 ## What are relays and NetComs?
 
-A **relay** is a communication component that routes messages between the OpCon server and agents. Relays support a primary/standby architecture — if the primary relay becomes unavailable, you can fail over to a standby relay to maintain agent communication.
+A **relay** is a communication component that routes messages between the OpCon server and agents when OpCon is hosted in Cloud and Agents are within customer's network premises. Relays support a primary/standby architecture — if the primary relay becomes unavailable, you can fail over to a standby relay to maintain agent communication.
 
-A **NetCom** (SMA Network Communications Module) is the underlying communication component that handles the direct connection between OpCon and its agents. NetComs can operate independently or through a relay.
+A **NetCom** (SMA Network Communications Module) is the communication component that handles the direct connection between OpCon and its agents when both are within same infrastructure (On-Prem OpCon Installations where both OpCon and Agents are within customer's network premises OR Both OpCon and Agents are in Cloud). A relay is not required in these configurations.
 
 ## Primary and standby architecture
 
@@ -39,7 +39,7 @@ The **Relays / NetComs** page uses a split-pane layout:
 Use the **Relays / NetComs** page to:
 
 - Monitor the communication status of relays and NetComs across your environment
-- Restart a relay that is in Standby or Stopped status
+- Restart a relay that is in Communicating or Standby status
 - Upgrade a relay to a newer version
 - View relay logs for troubleshooting
 - Perform a manual failover from a primary relay to a standby relay

--- a/docs/Files/UI/Solution-Manager/Library/Relays/Relays-Overview.md
+++ b/docs/Files/UI/Solution-Manager/Library/Relays/Relays-Overview.md
@@ -1,0 +1,55 @@
+---
+title: Relays overview
+description: "Understand what relays and NetComs are, how the primary/standby architecture works, and when to use the Relays / NetComs page in Solution Manager."
+tags:
+  - Conceptual
+  - System Administrator
+  - Automation Engineer
+  - Solution Manager
+---
+
+# Relays overview
+
+Relays and NetComs manage communication between the OpCon server and agents across your environment. The **Relays / NetComs** page in Solution Manager gives you visibility into the status of all relay and NetCom instances and lets you perform management operations on relays.
+
+## What are relays and NetComs?
+
+A **relay** is a communication component that routes messages between the OpCon server and agents. Relays support a primary/standby architecture — if the primary relay becomes unavailable, you can fail over to a standby relay to maintain agent communication.
+
+A **NetCom** (SMA Network Communications Module) is the underlying communication component that handles the direct connection between OpCon and its agents. NetComs can operate independently or through a relay.
+
+## Primary and standby architecture
+
+Relays use a priority-based architecture to support failover:
+
+- **Primary relay** — The active relay that handles all agent communication. Each relay name has one primary instance
+- **Standby relay** — One or more backup instances that can take over if the primary relay becomes unavailable. Standby relays are ranked by priority number, where lower numbers indicate higher priority
+
+When you perform a manual failover, OpCon transitions agent communication from the primary relay to a selected standby relay through a six-step process that drains messages, closes connections on the primary, and establishes new connections on the failover relay.
+
+## Page layout
+
+The **Relays / NetComs** page uses a split-pane layout:
+
+- **Upper pane** — The **Relays** grid displays all registered relay instances with their status, priority, version, and machine information. You can select relays to perform management actions such as restart, upgrade, view logs, and failover
+- **Lower pane** — The **NetComs** grid displays all registered NetCom instances with their status, version, and machine information. This grid is read-only and provides monitoring visibility only
+
+## When to use this page
+
+Use the **Relays / NetComs** page to:
+
+- Monitor the communication status of relays and NetComs across your environment
+- Restart a relay that is in Standby or Stopped status
+- Upgrade a relay to a newer version
+- View relay logs for troubleshooting
+- Perform a manual failover from a primary relay to a standby relay
+
+## Prerequisites
+
+All users can view the **Relays / NetComs** page. To perform relay management operations (restart, upgrade, and failover), you must have the OCADM role.
+
+## Related topics
+
+- [Managing relays](Managing-Relays.md)
+- [Relays reference](Relays-Reference.md)
+- [SMA Network Communications Module](../../../../../server-programs/network-communications.md)

--- a/docs/Files/UI/Solution-Manager/Library/Relays/Relays-Reference.md
+++ b/docs/Files/UI/Solution-Manager/Library/Relays/Relays-Reference.md
@@ -66,9 +66,9 @@ The following actions are available in the **Relays** grid toolbar. These action
 
 | Action | Availability |
 |---|---|
-| **Restart** | Available when a relay with a status of Standby or Stopped is selected |
-| **Upgrade** | Available when any relay is selected |
-| **Logs** | Available when any relay is selected |
+| **Restart** | Available when a relay with a status of Communicating or Standby is selected |
+| **Upgrade** | Available when a relay in Communicating or Standby status is selected and an upgrade is available for that relay version |
+| **Logs** | Available when any relay in Communicating or Standby status is selected |
 | **Choose Failover** | Available when all failover requirements are met. See [Failover requirements](#failover-requirements) |
 
 ## Failover requirements

--- a/docs/Files/UI/Solution-Manager/Library/Relays/Relays-Reference.md
+++ b/docs/Files/UI/Solution-Manager/Library/Relays/Relays-Reference.md
@@ -1,0 +1,124 @@
+---
+title: Relays reference
+description: "Field definitions, status values, failover transition steps, and permission requirements for the Relays / NetComs page in Solution Manager."
+tags:
+  - Reference
+  - System Administrator
+  - Automation Engineer
+  - Solution Manager
+---
+
+# Relays reference
+
+This page provides field definitions, status values, and action requirements for the **Relays / NetComs** page in Solution Manager. The page displays two grids: the **Relays** grid in the upper pane and the **NetComs** grid in the lower pane.
+
+For procedures, see [Managing relays](Managing-Relays.md). For an overview of relay architecture, see [Relays overview](Relays-Overview.md).
+
+## Relay grid columns
+
+The **Relays** grid displays all registered relay instances. You can search by name and filter by status.
+
+| Column | Description |
+|---|---|
+| **Name** | The name of the relay |
+| **Status** | The current communication status of the relay. See [Status values](#status-values) |
+| **Priority** | The relay's failover priority. See [Priority values](#priority-values) |
+| **Client Name** | The name of the client associated with the relay |
+| **Relay Machine** | The machine where the relay is running |
+| **Version** | The installed version of the relay software |
+| **Upgrade Date** | The date and time the relay was last upgraded |
+
+## NetCom grid columns
+
+The **NetComs** grid displays all registered NetCom instances. You can search by name and filter by status. The NetCom grid is read-only — you cannot select rows or perform actions on NetCom entries.
+
+| Column | Description |
+|---|---|
+| **Name** | The name of the NetCom instance |
+| **Status** | The current communication status of the NetCom. See [Status values](#status-values) |
+| **Client Name** | The name of the client associated with the NetCom |
+| **NetCom Machine** | The machine where the NetCom is running |
+| **Version** | The installed version of the NetCom software |
+| **Upgrade Date** | The date and time the NetCom was last upgraded |
+
+## Status values
+
+The following status values apply to both relay and NetCom entries.
+
+| Status | Description |
+|---|---|
+| Communicating | The relay or NetCom is actively communicating with the OpCon server |
+| Standby | The relay or NetCom is available but not actively communicating |
+| Stopped | The relay or NetCom is not running |
+
+## Priority values
+
+Priority values appear in the **Relays** grid only. They indicate the relay's role in the failover hierarchy.
+
+| Value | Meaning |
+|---|---|
+| Primary | The relay is the active primary relay (priority 0) |
+| 1, 2, 3... | The relay is a standby relay. Lower numbers indicate higher failover priority |
+
+## Relay actions
+
+The following actions are available in the **Relays** grid toolbar. These actions apply to relays only — no actions are available for NetCom entries.
+
+| Action | Availability |
+|---|---|
+| **Restart** | Available when a relay with a status of Standby or Stopped is selected |
+| **Upgrade** | Available when any relay is selected |
+| **Logs** | Available when any relay is selected |
+| **Choose Failover** | Available when all failover requirements are met. See [Failover requirements](#failover-requirements) |
+
+## Failover requirements
+
+The **Choose Failover** button is available only when all of the following conditions are met:
+
+- You have the OCADM role
+- Exactly one Primary relay is selected
+- The selected relay has a status of Communicating
+- A Standby relay with the same name exists
+
+## Failover transition steps
+
+The Relay Failover dialog displays a static transition process with six steps. 
+
+### Primary relay steps
+
+| Step | Name | Description |
+|---|---|---|
+| 1 | Stopping new messaging | Stops accepting new messages on the primary relay |
+| 2 | Draining message queues | Drains in-flight messages before handoff |
+| 3 | Closing primary relay | Terminates all agent connections on the primary relay |
+
+### Failover relay steps
+
+| Step | Name | Description |
+|---|---|---|
+| 4 | Reloading agent configuration | Reloads agent configuration on the failover relay |
+| 5 | Establishing failover relay connections | Establishes agent connections from the failover relay |
+| 6 | Starting send/receive from failover relay | Begins message send and receive on the failover relay |
+
+## Relay log file types
+
+The Relay Logs dialog displays three log files, each on a separate tab.
+
+| Log file | Description |
+|---|---|
+| SMANetComRelay.log | The main relay log with configuration and communication information |
+| SMANetComRelayAPI.log | The API communication log for relay operations |
+| SMANetComTrace.log | A detailed trace log with TCP/IP and socket connection information |
+
+## Timeouts
+
+| Operation | Timeout behavior |
+|---|---|
+| Failover | Polls for progress every 5 seconds. The operation times out after several minutes if the transition does not complete |
+| Restart | Polls for the relay to return to Communicating status. Times out after 2 minutes |
+
+## Related topics
+
+- [Relays overview](Relays-Overview.md)
+- [Managing relays](Managing-Relays.md)
+- [SMA Network Communications Module](../../../../../server-programs/network-communications.md)

--- a/docs/server-programs/network-communications.md
+++ b/docs/server-programs/network-communications.md
@@ -15,8 +15,12 @@ doc_type: procedural
 
 # SMA Network Communications Module (SMANetCom)
 
-**Theme:** Configure  
+**Theme:** Configure
 **Who Is It For?** System Administrator
+
+:::note
+To view NetComs in Solution Manager, see [Relays overview](../Files/UI/Solution-Manager/Library/Relays/Relays-Overview.md).
+:::
 
 ## What Is It?
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -396,7 +396,13 @@ module.exports = {
               type: "category",
               label: "Relay",
               collapsed: true,
+              link: {
+                type: "doc",
+                id: "Files/UI/Solution-Manager/Library/Relays/Relays-Overview",
+              },
               items: [
+                "Files/UI/Solution-Manager/Library/Relays/Managing-Relays",
+                "Files/UI/Solution-Manager/Library/Relays/Relays-Reference",
                 "server-programs/network-communications",
               ],
             },


### PR DESCRIPTION
Add sidebar navigation and documentation links for Relays and NetComs in Solution Manager

- Added a link to the Relays overview document in the sidebar under the Relay category.
- Updated the Network Communications documentation to include a note directing users to the Relays overview for better navigation and context.