### PR TITLE
Updated schedule-activity-monitor.md default license location.

### DIFF
--- a/docs/server-programs/schedule-activity-monitor.md
+++ b/docs/server-programs/schedule-activity-monitor.md
@@ -88,9 +88,9 @@ If the license file is encrypted after receipt (e.g., saved to a Windows folder 
 
 1. Open your email program and open the **email message** containing the license file
 2. Right-click the **license file** and select **Save As**
-3. Browse to the SAM Installation directory
+3. Browse to the SAM Data directory
     :::tip Example
-    C:\Program Files\OpConxps\SAM\
+    C:\ProgramData\OpConxps\SAM\
     :::
 4. Select the **Save** button
 

--- a/versioned_docs/version-22.0/server-programs/schedule-activity-monitor.md
+++ b/versioned_docs/version-22.0/server-programs/schedule-activity-monitor.md
@@ -72,8 +72,8 @@ If the license file is encrypted after being received from SMA Technologies (e.g
 1. Open your email program to get the license file from SMA Technologies.
 2. Open the **email message** containing the license file.
 3. Right-click the **license file** and select **Save As**.
-4. Browse to the SAM Installation directory.
+4. Browse to the SAM Data directory.
     :::tip Example
-    C:\Program Files\OpConxps\SAM\
+    C:\ProgramData\OpConxps\SAM\
     :::
 5. Click the **Save** button.

--- a/versioned_docs/version-23.0/server-programs/schedule-activity-monitor.md
+++ b/versioned_docs/version-23.0/server-programs/schedule-activity-monitor.md
@@ -72,8 +72,8 @@ If the license file is encrypted after being received from SMA Technologies (e.g
 1. Open your email program to get the license file from SMA Technologies.
 2. Open the **email message** containing the license file.
 3. Right-click the **license file** and select **Save As**.
-4. Browse to the SAM Installation directory.
+4. Browse to the SAM Data directory.
     :::tip Example
-    C:\Program Files\OpConxps\SAM\
+    C:\ProgramData\OpConxps\SAM\
     :::
 5. Click the **Save** button.

--- a/versioned_docs/version-25.0/server-programs/schedule-activity-monitor.md
+++ b/versioned_docs/version-25.0/server-programs/schedule-activity-monitor.md
@@ -72,8 +72,8 @@ If the license file is encrypted after being received from SMA Technologies (e.g
 1. Open your email program to get the license file from SMA Technologies.
 2. Open the **email message** containing the license file.
 3. Right-click the **license file** and select **Save As**.
-4. Browse to the SAM Installation directory.
+4. Browse to the SAM Data directory.
     :::tip Example
-    C:\Program Files\OpConxps\SAM\
+    C:\ProgramData\OpConxps\SAM\
     :::
 5. Click the **Save** button.

--- a/versioned_docs/version-26.0/server-programs/schedule-activity-monitor.md
+++ b/versioned_docs/version-26.0/server-programs/schedule-activity-monitor.md
@@ -88,9 +88,9 @@ If the license file is encrypted after receipt (e.g., saved to a Windows folder 
 
 1. Open your email program and open the **email message** containing the license file
 2. Right-click the **license file** and select **Save As**
-3. Browse to the SAM Installation directory
+3. Browse to the SAM Data directory
     :::tip Example
-    C:\Program Files\OpConxps\SAM\
+    C:\ProgramData\OpConxps\SAM\
     :::
 4. Select the **Save** button
 


### PR DESCRIPTION
Hello everyone,

SAM reads license files from the SAM Data Directory which is at C:\ProgramData\OpConxps\SAM by default. I've changed the schedule-activity-monitor.md files to reflect this to avoid confusion.