### PR TITLE
OCAG-804: Surface the convert-to-Batch restart workaround in opcon-docs

### DIFF
--- a/docs/Files/UI/Solution-Manager/Library/MasterJobs/Viewing-And-Updating-Master-Jobs/JobTaskDetails/ZOS-Job-Details.md
+++ b/docs/Files/UI/Solution-Manager/Library/MasterJobs/Viewing-And-Updating-Master-Jobs/JobTaskDetails/ZOS-Job-Details.md
@@ -126,7 +126,6 @@ Tracked and Queued jobs are identical in terms of job definition and scheduling.
 
 - **Tracked Job:** JCL is submitted to the JES queue from an external source and tracked dynamically by the agent. Should be defined on an OpCon Schedule with no dependencies
 - **Queued Job:** JCL is submitted to the JES queue from an external source and tracked dynamically by the agent. May have dependencies on other jobs or pre-runs; must arrive in a JES "held" queue or as a `TYPRUN=HOLD` job
-- Tracked Jobs should not be restarted from OpCon. Restarting only reports the original completion status. To restart a Tracked or Queued job, resubmit it from the original source
 
 ### Sysplex
 

--- a/docs/job-types/zos.md
+++ b/docs/job-types/zos.md
@@ -255,11 +255,9 @@ As far as job definition and scheduling are concerned, Tracked and Queued jobs a
     submitted to the JES queue from an external source and is tracked
     dynamically by the agent. These jobs may have     dependencies on other jobs or pre-runs and must arrive in a JES
     "held" queue or as a TYPRUN=HOLD job.
-- Tracked Jobs should not be restarted from
-    OpCon. Attempting to restart a Tracked
-    Job will only result in the original completion status being
-    reported. To restart a Tracked or Queued job, re-submit it from the
-    original source.
+- Tracked Jobs cannot be restarted directly from OpCon — a restart only reports the original completion status. To re-run a Tracked or Queued job, do one of the following:
+    - Resubmit the job from its original external source.
+    - Convert the **z/OS Job Type** to **Batch**, import the JCL into an OpCon library, and restart from OpCon. See [Restarting External Jobs through OpCon](https://help.smatechnologies.com/opcon/agents/zos/advanced-features/restarting-jobs) in the z/OS Agent help.
 
 The following information applies to defining *Tracked Job* and *Queued
 Job Controls*:


### PR DESCRIPTION
The tracked z/OS job warning told customers to resubmit from the original source but did not mention the convert-to-Batch + import-JCL path that the z/OS Agent docs already document. Expand the warning on the z/OS Jobs page with both options and a deep link to the procedure, and trim the duplicate bullet from the UI reference page so restart guidance lives in one place.