### PR TITLE
Add ResourceMonitor 21.0.0 and 21.1.0 release notes

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -5,6 +5,26 @@ doc_type: conceptual
 
 # OpCon Release Notes
 
+## ResourceMonitor
+
+#### 21.1.0
+
+**Bug Fix**
+
+:white_check_mark: **Log-archive retention now respects the INI file**: The ArchiveDaysToKeep setting configured in the INI file is now applied correctly at service startup. In prior releases this value was ignored and the default retention was used instead.
+
+#### 21.0.0
+
+**FIPS Compliance & .NET Framework 4.8.1**
+
+:eight_spoked_asterisk: ResourceMonitor has been updated to be FIPS-compliant and now runs on .NET Framework 4.8.1. Both the service and the UI have been rebuilt against the latest FIPS-compliant SMA libraries, and the installer automatically deploys the .NET Framework 4.8.1 runtime as a prerequisite where it is not already present.
+
+**Other Improvements**
+
+:eight_spoked_asterisk: Service startup and logging-initialization errors are now written to the Windows Event Log, making installation and configuration issues easier to diagnose.
+
+:eight_spoked_asterisk: Improved service responsiveness and a cleaner, faster service shutdown.
+
 ## Winter 26
 
 #### 26.0.2

--- a/versioned_docs/version-26.0/release-notes.md
+++ b/versioned_docs/version-26.0/release-notes.md
@@ -5,6 +5,26 @@ doc_type: conceptual
 
 # OpCon Release Notes
 
+## ResourceMonitor
+
+#### 21.1.0
+
+**Bug Fix**
+
+:white_check_mark: **Log-archive retention now respects the INI file**: The ArchiveDaysToKeep setting configured in the INI file is now applied correctly at service startup. In prior releases this value was ignored and the default retention was used instead.
+
+#### 21.0.0
+
+**FIPS Compliance & .NET Framework 4.8.1**
+
+:eight_spoked_asterisk: ResourceMonitor has been updated to be FIPS-compliant and now runs on .NET Framework 4.8.1. Both the service and the UI have been rebuilt against the latest FIPS-compliant SMA libraries, and the installer automatically deploys the .NET Framework 4.8.1 runtime as a prerequisite where it is not already present.
+
+**Other Improvements**
+
+:eight_spoked_asterisk: Service startup and logging-initialization errors are now written to the Windows Event Log, making installation and configuration issues easier to diagnose.
+
+:eight_spoked_asterisk: Improved service responsiveness and a cleaner, faster service shutdown.
+
 ## OpCon 26.0.4
 
 **NOTE**: Verify/Upgrade these components if applicable:


### PR DESCRIPTION
## Summary

- Adds a new top-level `## ResourceMonitor` section to both `docs/release-notes.md` and `versioned_docs/version-26.0/release-notes.md`.
- **21.1.0** — bug fix: `ArchiveDaysToKeep` from the INI file is now honored at service startup (previously the default retention was used).
- **21.0.0** — FIPS compliance, .NET Framework 4.8.1 runtime (auto-deployed by the installer), Windows Event Log diagnostics for startup/logging-init errors, and improved service responsiveness/shutdown.

## Test plan

- [ ] `yarn build` passes locally
- [ ] New ResourceMonitor section renders correctly in the dev server for both current and version-26.0 docs
- [ ] No CI broken-link or build regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)