### PR TITLE
Fix broken Debug Options table on SMANetCom page

### DIFF
--- a/docs/server-programs/network-communications.md
+++ b/docs/server-programs/network-communications.md
@@ -186,7 +186,7 @@ The Secondary Mode Settings are reserved for future use.
 
 The Debug Options configure the SMANetCom logging behavior.
 
-+|Debug Options|Default|Dynamic (Y/N)|Description|
+|Debug Options|Default|Dynamic (Y/N)|Description|
 |--- |--- |--- |--- |
 |MaximumLogFileSize|150000|Y|Defines the maximum size in bytes for each log file. Determines when the current log file is closed and a new file is started. When the file reaches this maximum size, it is "rolled over." This setting creates small, manageable log files. SMANetCom.log resides in the <Output Directory\>\SAM\Log directory. When the log file reaches the maximum size, SMANetCom archives the log file. When SMANetCom is installed with the SAM, the SAM maintains the archive folders. Note: Each SMANetCom instance based on its SMANetComName has its SMANetCom log file as mentioned in the Details of Service Settings.|
 |TraceSAMMessages|ON|Y|Enables/Disables SMANetCom to create the SMANetComTrace log file. If OFF, SMANetCom creates only the SMANetCom log file. If ON, SMANetCom creates both the SMANetCom log and SMANetComTrace log files. The SMANetComTrace log contains all records regarding TX messages. Continuous strongly recommends leaving this value set to ON. Note: Each SMANetCom instance based on its SMANetComName has its own SMANetComTrace log file as mentioned in the Details of Service Settings.|

--- a/versioned_docs/version-22.0/server-programs/network-communications.md
+++ b/versioned_docs/version-22.0/server-programs/network-communications.md
@@ -154,7 +154,7 @@ The Secondary Mode Settings are reserved for future use.
 
 The Debug Options configure the SMANetCom logging behavior.
 
-+|Debug Options|Default|Dynamic (Y/N)|Description|
+|Debug Options|Default|Dynamic (Y/N)|Description|
 |--- |--- |--- |--- |
 |MaximumLogFileSize|150000|Y|Defines the maximum size in bytes for each log file. Determines when the current log file is closed and a new file is started. When the file reaches this maximum size, it is "rolled over." This setting creates small, manageable log files. SMANetCom.log resides in the <Output Directory\>\SAM\Log directory. When the log file reaches the maximum size, SMANetCom archives the log file. When SMANetCom is installed with the SAM, the SAM maintains the archive folders. Note: Each SMANetCom instance based on its SMANetComName has its SMANetCom log file as mentioned in the Details of Service Settings.|
 |TraceSAMMessages|ON|Y|Enables/Disables SMANetCom to create the SMANetComTrace log file. If OFF, SMANetCom creates only the SMANetCom log file. If ON, SMANetCom creates both the SMANetCom log and SMANetComTrace log files. The SMANetComTrace log contains all records regarding TX messages. SMA Technologies strongly recommends leaving this value set to ON. Note: Each SMANetCom instance based on its SMANetComName has its own SMANetComTrace log file as mentioned in the Details of Service Settings.|

--- a/versioned_docs/version-23.0/server-programs/network-communications.md
+++ b/versioned_docs/version-23.0/server-programs/network-communications.md
@@ -154,7 +154,7 @@ The Secondary Mode Settings are reserved for future use.
 
 The Debug Options configure the SMANetCom logging behavior.
 
-+|Debug Options|Default|Dynamic (Y/N)|Description|
+|Debug Options|Default|Dynamic (Y/N)|Description|
 |--- |--- |--- |--- |
 |MaximumLogFileSize|150000|Y|Defines the maximum size in bytes for each log file. Determines when the current log file is closed and a new file is started. When the file reaches this maximum size, it is "rolled over." This setting creates small, manageable log files. SMANetCom.log resides in the <Output Directory\>\SAM\Log directory. When the log file reaches the maximum size, SMANetCom archives the log file. When SMANetCom is installed with the SAM, the SAM maintains the archive folders. Note: Each SMANetCom instance based on its SMANetComName has its SMANetCom log file as mentioned in the Details of Service Settings.|
 |TraceSAMMessages|ON|Y|Enables/Disables SMANetCom to create the SMANetComTrace log file. If OFF, SMANetCom creates only the SMANetCom log file. If ON, SMANetCom creates both the SMANetCom log and SMANetComTrace log files. The SMANetComTrace log contains all records regarding TX messages. SMA Technologies strongly recommends leaving this value set to ON. Note: Each SMANetCom instance based on its SMANetComName has its own SMANetComTrace log file as mentioned in the Details of Service Settings.|

--- a/versioned_docs/version-25.0/server-programs/network-communications.md
+++ b/versioned_docs/version-25.0/server-programs/network-communications.md
@@ -154,7 +154,7 @@ The Secondary Mode Settings are reserved for future use.
 
 The Debug Options configure the SMANetCom logging behavior.
 
-+|Debug Options|Default|Dynamic (Y/N)|Description|
+|Debug Options|Default|Dynamic (Y/N)|Description|
 |--- |--- |--- |--- |
 |MaximumLogFileSize|150000|Y|Defines the maximum size in bytes for each log file. Determines when the current log file is closed and a new file is started. When the file reaches this maximum size, it is "rolled over." This setting creates small, manageable log files. SMANetCom.log resides in the <Output Directory\>\SAM\Log directory. When the log file reaches the maximum size, SMANetCom archives the log file. When SMANetCom is installed with the SAM, the SAM maintains the archive folders. Note: Each SMANetCom instance based on its SMANetComName has its SMANetCom log file as mentioned in the Details of Service Settings.|
 |TraceSAMMessages|ON|Y|Enables/Disables SMANetCom to create the SMANetComTrace log file. If OFF, SMANetCom creates only the SMANetCom log file. If ON, SMANetCom creates both the SMANetCom log and SMANetComTrace log files. The SMANetComTrace log contains all records regarding TX messages. SMA Technologies strongly recommends leaving this value set to ON. Note: Each SMANetCom instance based on its SMANetComName has its own SMANetComTrace log file as mentioned in the Details of Service Settings.|

--- a/versioned_docs/version-26.0/server-programs/network-communications.md
+++ b/versioned_docs/version-26.0/server-programs/network-communications.md
@@ -182,7 +182,7 @@ The Secondary Mode Settings are reserved for future use.
 
 The Debug Options configure the SMANetCom logging behavior.
 
-+|Debug Options|Default|Dynamic (Y/N)|Description|
+|Debug Options|Default|Dynamic (Y/N)|Description|
 |--- |--- |--- |--- |
 |MaximumLogFileSize|150000|Y|Defines the maximum size in bytes for each log file. Determines when the current log file is closed and a new file is started. When the file reaches this maximum size, it is "rolled over." This setting creates small, manageable log files. SMANetCom.log resides in the <Output Directory\>\SAM\Log directory. When the log file reaches the maximum size, SMANetCom archives the log file. When SMANetCom is installed with the SAM, the SAM maintains the archive folders. Note: Each SMANetCom instance based on its SMANetComName has its SMANetCom log file as mentioned in the Details of Service Settings.|
 |TraceSAMMessages|ON|Y|Enables/Disables SMANetCom to create the SMANetComTrace log file. If OFF, SMANetCom creates only the SMANetCom log file. If ON, SMANetCom creates both the SMANetCom log and SMANetComTrace log files. The SMANetComTrace log contains all records regarding TX messages. Continuous strongly recommends leaving this value set to ON. Note: Each SMANetCom instance based on its SMANetComName has its own SMANetComTrace log file as mentioned in the Details of Service Settings.|


### PR DESCRIPTION
## Summary

- Removes a stray `+` character preceding the Debug Options table header row on the SMANetCom (network-communications) page. The `+` broke markdown table rendering, leaving the header row as raw text and the table without a usable header.
- Applied to the current docs and all four versioned snapshots:
  - `docs/server-programs/network-communications.md`
  - `versioned_docs/version-22.0/server-programs/network-communications.md`
  - `versioned_docs/version-23.0/server-programs/network-communications.md`
  - `versioned_docs/version-25.0/server-programs/network-communications.md`
  - `versioned_docs/version-26.0/server-programs/network-communications.md`

## Test plan

- [ ] `yarn build` passes locally
- [ ] Debug Options table renders correctly on the SMANetCom page in the current docs and each versioned snapshot
- [ ] No other regressions on the page (other tables, links, headings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)