### PR TITLE
Add REST API link to Reference section on index page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,7 @@ OpCon (Operations Console Cross-Platform Scheduler) is an enterprise-wide, heter
   - [Triggers](./notifications/Notification-Triggers.md)
   - [Actions](./notifications/Notification-Configuration.md)
 - [Reports](./reports/overview.md)
+- [REST API](https://help.smatechnologies.com/opcon/core/api/26-0.html)
 
 </div>
 


### PR DESCRIPTION
## Summary

- Adds a "REST API" link to the Reference card on the docs landing page (`docs/index.md`).
- Points to `https://help.smatechnologies.com/opcon/core/api/26-0.html`, the same external URL already used by the sidebar.

## Test plan

- [ ] `yarn build` passes locally
- [ ] "REST API" link appears in the Reference card on the index page
- [ ] Link opens the external REST API docs page

🤖 Generated with [Claude Code](https://claude.com/claude-code)