### PR TITLE
Bump current release on v25 index page to OpCon 25.0.7

### DIFF
--- a/versioned_docs/version-25.0/index.md
+++ b/versioned_docs/version-25.0/index.md
@@ -6,7 +6,7 @@ slug: "/"
 
 OpCon (Operations Console Cross-Platform Scheduler) is an enterprise-wide, heterogeneous workflow automation and orchestration platform.
 
-The current release is **OpCon 25.0.6**.
+The current release is **OpCon 25.0.7**.
 
 The following sections contain more information:
 


### PR DESCRIPTION
## Summary

- Updates the "current release" marker on `versioned_docs/version-25.0/index.md` from **OpCon 25.0.6** to **OpCon 25.0.7**.

## Notes

- The v25 release notes (`versioned_docs/version-25.0/release-notes.md`) still show `## OpCon 25.0.6` as the most recent section. A 25.0.7 release-notes section will be added separately.

## Test plan

- [ ] `yarn build` passes locally
- [ ] v25 index page shows "The current release is **OpCon 25.0.7**."

🤖 Generated with [Claude Code](https://claude.com/claude-code)