### PR TITLE
OCAG-1105 – OS 2200 token documentation corrections and date token section

### DIFF
--- a/docs/Files/UI/Solution-Manager/Library/MasterJobs/Viewing-And-Updating-Master-Jobs/JobTaskDetails/Os2200-Job-Details.md
+++ b/docs/Files/UI/Solution-Manager/Library/MasterJobs/Viewing-And-Updating-Master-Jobs/JobTaskDetails/Os2200-Job-Details.md
@@ -75,7 +75,7 @@ When an Agent-started job terminates, the run condition word is evaluated for co
 
 | Field | Description | Values |
 |---|---|---|
-| **And/Or** | Determines the association between multiple tests. | `AND`, `OR` |
+| **And/Or** | Determines the association between multiple tests. Available on the second through fourth tests; the first test has no preceding test to combine. | `None`, `AND`, `OR` |
 | **Word Part** | The portion of the word to analyze. | `S1`, `S2`, `S3`, `S4`, `S5`, `S6`, `T1`, `T2`, `T3` |
 | **Condition** | How the word part is tested. | `LAND`, `LT`, `LE`, `EQ`, `NE`, `GE`, `GT`, `Range` |
 | **Value** | The value compared against the selected word part. | — |

--- a/docs/job-types/os-2200.md
+++ b/docs/job-types/os-2200.md
@@ -181,6 +181,12 @@ When the ECL contains `?FILEDATE?`, the Agent replaces it with the schedule date
 
 :::
 
+:::info
+
+All of the date formats listed below, and many more, can also be produced directly using [Managed System Properties](../objects/properties.md#Managed) such as `[[$SCHEDULE DATE]]` with format characters or offset syntax (for example, `[[$SCHEDULE DATE(+1d)]]` for tomorrow's date). When a managed system property produces the exact value you need, using it directly in the ECL is simpler than defining an OS 2200 Agent date token. The OS 2200 Agent date tokens are most useful when the ECL must contain a specific format that the managed system properties do not produce, or when you need several date values derived from the same base date.
+
+:::
+
 **Prerequisite:** The first token equation must supply the base date for all calculations. The value must be in `YYYYMMDD/W/N` format, where `W` is the numeric day of week (1=Sunday through 7=Saturday) and `N` is the number of work days per week. OpCon's `[[$SCHEDULE DATE]]` property delivers exactly this format. If the first token value does not match this format, date-keyword substitutions are skipped silently — no error is raised.
 
 The Agent supports up to 16 token equations total. The first equation is reserved for the base date; the remaining 15 may use any combination of date keywords or literal values.

--- a/docs/job-types/os-2200.md
+++ b/docs/job-types/os-2200.md
@@ -191,24 +191,24 @@ All of the date formats listed below, and many more, can also be produced direct
 
 The Agent supports up to 16 token equations total. The first equation is reserved for the base date; the remaining 15 may use any combination of date keywords or literal values.
 
-| Value-format keyword | Output | Example (2026-06-09) |
-|---|---|---|
-| `DD` | Day of month | `09` |
-| `MM` | Month | `06` |
-| `MMDD` | Month and day | `0609` |
-| `JJMM` | Year and month (YYMM) | `2606` |
-| `JJMMDD` | Date (YYMMDD) | `260609` |
-| `MMJJ` | Month and year (MMYY) | `0626` |
-| `J` | Last digit of year | `6` |
-| `EEJJ` | 4-digit year | `2026` |
-| `EEJJMM` | Year and month (YYYYMM) | `202606` |
-| `EEJJMMDD` | Full date (YYYYMMDD) | `20260609` |
-| `EEJJMMDD-1` | Previous day (YYYYMMDD) | `20260608` |
-| `EEJJMM-1` | Previous month (YYYYMM) | `202605` |
-| `JJMM-1` | Previous month (YYMM) | `2605` |
-| `JJMMDD-1` | Previous day (YYMMDD) | `260608` |
-| `MMDD-1` | Previous day (MMDD) | `0608` |
-| `MM-1JJ` | Previous month (MMYY) | `0526` |
+| Value-format keyword | Output | Example (2026-06-09) | Managed property format |
+|---|---|---|---|
+| `DD` | Day of month | `09` | `dd` |
+| `MM` | Month | `06` | `mm` |
+| `MMDD` | Month and day | `0609` | `mmdd` |
+| `JJMM` | Year and month (YYMM) | `2606` | `yymm` |
+| `JJMMDD` | Date (YYMMDD) | `260609` | `yymmdd` |
+| `MMJJ` | Month and year (MMYY) | `0626` | `mmyy` |
+| `J` | Last digit of year | `6` | — |
+| `EEJJ` | 4-digit year | `2026` | `yyyy` |
+| `EEJJMM` | Year and month (YYYYMM) | `202606` | `yyyymm` |
+| `EEJJMMDD` | Full date (YYYYMMDD) | `20260609` | `yyyymmdd` |
+| `EEJJMMDD-1` | Previous day (YYYYMMDD) | `20260608` | `yyyymmdd` with `-1d` offset |
+| `EEJJMM-1` | Previous month (YYYYMM) | `202605` | `yyyymm` with `-1m` offset |
+| `JJMM-1` | Previous month (YYMM) | `2605` | `yymm` with `-1m` offset |
+| `JJMMDD-1` | Previous day (YYMMDD) | `260608` | `yymmdd` with `-1d` offset |
+| `MMDD-1` | Previous day (MMDD) | `0608` | `mmdd` with `-1d` offset |
+| `MM-1JJ` | Previous month (MMYY) | `0526` | `mmyy` with `-1m` offset |
 
 An unrecognized value-format keyword is treated as a literal string and substituted as-is.
 

--- a/docs/job-types/os-2200.md
+++ b/docs/job-types/os-2200.md
@@ -160,9 +160,51 @@ The following tokens are resolved by the OS 2200 Agent and do not require defini
 | Token String | Equates To |
 |---|---|
 | `????????OPCON-JOBID????????` | Full OpCon Job ID (27 characters) |
-| `???JOB-ID???` | OpCon Job ID (first 12 characters) |
-| `?JOB-ID?` | OpCon Job ID (first 8 characters) |
+| `???JOB-ID???` | LSAM Job ID — 12-character-wide token; no ECL line shifting |
+| `?JOB-ID?` | LSAM Job ID — 8-character-wide token; the ECL line shifts right if the job name exceeds 8 characters |
 | `?RNID?` | Job's Run ID (6 characters) |
+| `??LSAMQUAL??` | LSAM file qualifier (note the double question marks) |
+
+`???JOB-ID???` and `?JOB-ID?` resolve to the same value. Use `???JOB-ID???` when the job name may be up to 12 characters to avoid unintended ECL shifting.
+
+### Date tokens
+
+The OS 2200 Agent supports date value substitution through a set of recognized value-format keywords. To use date substitution, define token equations where the right-hand side is one of the keywords in the table below. The left-hand side is the string you place in the ECL.
+
+:::tip Example
+
+```
+?SCHEDDATE?=[[$SCHEDULE DATE]],?FILEDATE?=EEJJMMDD,?PREVDAY?=EEJJMMDD-1
+```
+
+When the ECL contains `?FILEDATE?`, the Agent replaces it with the schedule date in YYYYMMDD format. `?PREVDAY?` is replaced with the previous day.
+
+:::
+
+**Prerequisite:** The first token equation must supply the base date for all calculations. The value must be in `YYYYMMDD/W/N` format, where `W` is the numeric day of week (1=Sunday through 7=Saturday) and `N` is the number of work days per week. OpCon's `[[$SCHEDULE DATE]]` property delivers exactly this format. If the first token value does not match this format, date-keyword substitutions are skipped silently — no error is raised.
+
+The Agent supports up to 16 token equations total. The first equation is reserved for the base date; the remaining 15 may use any combination of date keywords or literal values.
+
+| Value-format keyword | Output | Example (2026-06-09) |
+|---|---|---|
+| `DD` | Day of month | `09` |
+| `MM` | Month | `06` |
+| `MMDD` | Month and day | `0609` |
+| `JJMM` | Year and month (YYMM) | `2606` |
+| `JJMMDD` | Date (YYMMDD) | `260609` |
+| `MMJJ` | Month and year (MMYY) | `0626` |
+| `J` | Last digit of year | `6` |
+| `EEJJ` | 4-digit year | `2026` |
+| `EEJJMM` | Year and month (YYYYMM) | `202606` |
+| `EEJJMMDD` | Full date (YYYYMMDD) | `20260609` |
+| `EEJJMMDD-1` | Previous day (YYYYMMDD) | `20260608` |
+| `EEJJMM-1` | Previous month (YYYYMM) | `202605` |
+| `JJMM-1` | Previous month (YYMM) | `2605` |
+| `JJMMDD-1` | Previous day (YYMMDD) | `260608` |
+| `MMDD-1` | Previous day (MMDD) | `0608` |
+| `MM-1JJ` | Previous month (MMYY) | `0526` |
+
+An unrecognized value-format keyword is treated as a literal string and substituted as-is.
 
 ## FAQs
 
@@ -176,7 +218,7 @@ Yes. Text fields in the graphical interfaces support OpCon token replacement. To
 
 **Q: What special tokens are available for OS 2200 jobs?**
 
-OS 2200 supports tokens such as `???JOB-ID???` (OpCon Job ID, first 12 characters), `?JOB-ID?` (first 8 characters), and `?RNID?` (the job's 6-character Run ID).
+The OS 2200 Agent resolves several tokens automatically without requiring a token equation. These include `????????OPCON-JOBID????????` (full 27-character OpCon Job ID), `???JOB-ID???` (LSAM Job ID in a 12-character-wide slot), `?JOB-ID?` (same value in an 8-character-wide slot), `?RNID?` (6-character Run ID), and `??LSAMQUAL??` (LSAM file qualifier). The agent also supports date value-format keywords for date substitution — see the Date tokens section above.
 
 **Q: How many file dependencies and completion status tests can a job have?**
 

--- a/docs/job-types/os-2200.md
+++ b/docs/job-types/os-2200.md
@@ -160,10 +160,10 @@ The following tokens are resolved by the OS 2200 Agent and do not require defini
 | Token String | Equates To |
 |---|---|
 | `????????OPCON-JOBID????????` | Full OpCon Job ID (27 characters) |
-| `???JOB-ID???` | LSAM Job ID — 12-character-wide token; no ECL line shifting |
-| `?JOB-ID?` | LSAM Job ID — 8-character-wide token; the ECL line shifts right if the job name exceeds 8 characters |
+| `???JOB-ID???` | Agent Job ID — 12-character-wide token; no ECL line shifting |
+| `?JOB-ID?` | Agent Job ID — 8-character-wide token; the ECL line shifts right if the job name exceeds 8 characters |
 | `?RNID?` | Job's Run ID (6 characters) |
-| `??LSAMQUAL??` | LSAM file qualifier (note the double question marks) |
+| `??LSAMQUAL??` | Agent file qualifier (note the double question marks) |
 
 `???JOB-ID???` and `?JOB-ID?` resolve to the same value. Use `???JOB-ID???` when the job name may be up to 12 characters to avoid unintended ECL shifting.
 
@@ -224,7 +224,7 @@ Yes. Text fields in the graphical interfaces support OpCon token replacement. To
 
 **Q: What special tokens are available for OS 2200 jobs?**
 
-The OS 2200 Agent resolves several tokens automatically without requiring a token equation. These include `????????OPCON-JOBID????????` (full 27-character OpCon Job ID), `???JOB-ID???` (LSAM Job ID in a 12-character-wide slot), `?JOB-ID?` (same value in an 8-character-wide slot), `?RNID?` (6-character Run ID), and `??LSAMQUAL??` (LSAM file qualifier). The agent also supports date value-format keywords for date substitution — see the Date tokens section above.
+The OS 2200 Agent resolves several tokens automatically without requiring a token equation. These include `????????OPCON-JOBID????????` (full 27-character OpCon Job ID), `???JOB-ID???` (Agent Job ID in a 12-character-wide slot), `?JOB-ID?` (same value in an 8-character-wide slot), `?RNID?` (6-character Run ID), and `??LSAMQUAL??` (Agent file qualifier). The agent also supports date value-format keywords for date substitution — see the Date tokens section above.
 
 **Q: How many file dependencies and completion status tests can a job have?**
 


### PR DESCRIPTION
Corrects inaccuracies in the OS 2200 job type reference and adds documentation for date token substitution.

### Corrections to automatic token table (`docs/job-types/os-2200.md`)

- Replaced "first 12/8 characters" descriptions for `???JOB-ID???` and `?JOB-ID?` with accurate slot-width language. Both tokens resolve to the same full LSAM Job ID value; the difference is the width of the ECL slot they occupy, not a truncation of the value.
- Added `??LSAMQUAL??` (LSAM file qualifier) to the automatic token table — this token was previously undocumented in the user-facing reference.
- Updated the FAQ to include `????????OPCON-JOBID????????` and corrected the slot-width language to match the table.

### New: Date tokens section (`docs/job-types/os-2200.md`)

- Documents the value-format keywords (`DD`, `MM`, `EEJJMMDD`, etc.) supported by the OS 2200 Agent for date substitution.
- Explains the `YYYYMMDD/W/N` base-date format requirement: the first token equation must supply a date in this format (typically via `[[$SCHEDULE DATE]]`) or date-keyword substitutions are silently skipped.
- Includes an informational note cross-referencing Managed System Properties as a simpler alternative for many date formats, with a comparison column in the keyword table showing the equivalent managed property format string for each keyword.

### Correction to Os2200-Job-Details.md

- Added `None` as a valid value for the **And/Or** field in the Completion Status table. The first condition test has no preceding test to combine, so `None` is the correct initial value.
