### PR TITLE
Add z/OS Agent Feedback reference page

### DIFF
--- a/docs/Files/UI/Solution-Manager/Library/MasterJobs/Viewing-And-Updating-Master-Jobs/JobTaskDetails/ZOS-Job-Details.md
+++ b/docs/Files/UI/Solution-Manager/Library/MasterJobs/Viewing-And-Updating-Master-Jobs/JobTaskDetails/ZOS-Job-Details.md
@@ -177,10 +177,7 @@ Step Control allows up to 80 step condition codes or ranges. Special schedule or
     - `$JOB:BAD` — sets the job to Failed immediately.
     - `$S=jobstep[.procstep]` — sets the job's restart step.
   - Agent Feedback codes can trigger job events and are the preferred method for defining step triggers, because all event types are supported and events can contain instance properties. Multiple trigger events can be defined for the same message.
-  - Step completion status is written to the Step Completion agent Feedback table in a fixed format:
-    - A five-character status code: **Cnnnn** (condition code), **FLUSH** (step did not run), **Unnnn** (decimal abend code), or **S-xxx** (hexadecimal abend code).
-    - A space.
-    - The step name in `execstep` or `jobstep.execstep` format.
+  - Step completion status is written to the Step Completion agent Feedback table. For the value format and a full list of z/OS Agent Feedback types, refer to [z/OS Agent Feedback](../../../../../../../reference/zos-agent-feedback.md).
   - Automatic restart step selection can be enabled or disabled by prefixing the restart step name:
     - `+` — enables auto step flag, then sets restart step from the remainder of the message.
     - `-` — disables auto step flag, then sets restart step from the remainder of the message.

--- a/docs/job-components/events.md
+++ b/docs/job-components/events.md
@@ -50,7 +50,7 @@ If the Server Option "Allow Wild Cards in Events" is enabled, \* (asterisk) and 
       - SAP R/3 and CRM
       - UNIX
       - Windows
-      - z/OS
+      - z/OS — for the full list of feedback types and value formats, refer to [z/OS Agent Feedback](../reference/zos-agent-feedback.md)
     - **String to match**: String to compare against the agent feedback value using SQL pattern matching
       - Use `%` (not `*`) as a wildcard
       - Use `_` (not `?`) for a single-character wildcard

--- a/docs/job-types/zos.md
+++ b/docs/job-types/zos.md
@@ -372,18 +372,7 @@ The following information applies to defining Step Control:
     - The status of each step is written to the **Step
             Completion** agent Feedback table, so it provides an
             alternate way to define triggers, which does not require a
-            step control definition. These messages have a fixed format,
-            making it easy to match on all or part of the result:
-      - A five character status code:
-        - **Cnnnn**, where **nnnn** is the decimal condition
-                    code
-        - **FLUSH**, if the step did not run
-        - **Unnnn**, where **nnnn** is the decimal abend code
-        - **S-xxx**, where **xxx** is the hexadecimal abend
-                    code.
-      - A space
-      - The step name, in *execstep* or *jobstep.execstep*
-                format
+            step control definition. For the value format and a full list of z/OS Agent Feedback types, refer to [z/OS Agent Feedback](../reference/zos-agent-feedback.md)
 
   - Automatic restart step selection at the job or step level can be
         enabled or disabled. This will be controlled through prefixing

--- a/docs/reference/Reference-Section-Overview.md
+++ b/docs/reference/Reference-Section-Overview.md
@@ -42,6 +42,7 @@ The Reference section provides lookup material for OpCon events, notification co
 | Operations Machine Messages | Status and error messages returned by agents while a job runs or completes |
 | Operations File Transfer Messages | Error codes for file transfer jobs |
 | Windows System Errors | Windows error code reference (codes 0–499) |
+| z/OS Agent Feedback | Reference for the feedback types the z/OS Agent sends to OpCon, what each one represents, and the format of its value |
 | License & Support | License information, Solution Manager version, and SMA support resources |
 | CloudEvents Triggers | Reference for cloud-based event trigger configuration |
 | File Locations | Default installation directories and file paths |

--- a/docs/reference/zos-agent-feedback.md
+++ b/docs/reference/zos-agent-feedback.md
@@ -1,0 +1,88 @@
+---
+title: z/OS Agent Feedback
+description: "Reference for the feedback types the z/OS Agent sends to OpCon, what each one represents, and the format of its value."
+product_area: Reference
+audience: Automation Engineer
+version_introduced: "[see release notes]"
+tags:
+  - Reference
+  - Automation Engineer
+  - Agents
+last_updated: 2026-04-29
+doc_type: reference
+---
+
+# z/OS Agent Feedback
+
+**Theme:** Configure  
+**Who Is It For?** Automation Engineer
+
+## What Is It?
+
+The z/OS Agent reports activity to OpCon as Agent Feedback messages. Each feedback type has a name, carries a specific kind of information, and uses a specific value format. Use these names and formats when defining event criteria, job-completion expressions, or other OpCon objects that match against z/OS Agent Feedback values.
+
+## Feedback types
+
+| Name | Description | Format |
+| --- | --- | --- |
+| User Message | Trigger message sent from a step control definition or from a `--MSG` directive in JCL. Posted to Schedule Operations and available as event criteria. | Free text up to 20 characters. Supports the special tokens listed in [User Message tokens](#user-message-tokens). |
+| Step Completion | Reported at the end of each job step. Carries the step status code and step name. Not sent for tracked jobs. | A five-character status code, a space, and the step name. See [Step Completion format](#step-completion-format). |
+| Trigger Messages | Console message text that satisfied a `$JOBTRIG` WTO trigger, or dataset event text that satisfied a DSN trigger. Sent when a message-trigger pre-run condition fires. | Variable-length string. See [Trigger Messages format](#trigger-messages-format). |
+
+## Step Completion format
+
+Each Step Completion value has three parts:
+
+1. **Status code** — five characters identifying how the step ended:
+
+    | Code | Meaning |
+    | --- | --- |
+    | `Cnnnn` | Step ended with condition code `nnnn` (decimal) |
+    | `FLUSH` | Step did not run |
+    | `Unnnn` | Step ended with user abend code `nnnn` (decimal) |
+    | `S-xxx` | Step ended with system abend code `xxx` (hexadecimal) |
+
+2. **A single space** separating the status code from the step name.
+
+3. **Step name** in `execstep` or `jobstep.execstep` format, where `jobstep` is the name on the job-level EXEC statement and `execstep` is the name on the EXEC PGM statement in the procedure.
+
+Examples:
+
+- `C0000 STEP01` — STEP01 ended with condition code 0
+- `U0016 STEP02.RUN` — RUN inside STEP02 ended with user abend 16
+- `S-0C7 STEP03` — STEP03 ended with system abend S0C7
+- `FLUSH STEP04` — STEP04 did not run
+
+## User Message tokens
+
+A User Message can contain plain text or one of the following tokens. Tokens are interpreted by the z/OS Agent and trigger an immediate action.
+
+| Token | Action |
+| --- | --- |
+| `$EVENT=eventname` | Triggers the action defined for `eventname` in the z/OS event trigger table. If the name is not found, the message is changed to `JEVENT=eventname` and sent like any other message. |
+| `$JOB:GOOD` | Sets the job to Finished OK immediately. |
+| `$JOB:BAD` | Sets the job to Failed immediately. |
+| `$S=jobstep[.procstep]` | Sets the job's restart step to `jobstep[.procstep]`. |
+
+## Trigger Messages format
+
+Trigger Messages take one of two forms depending on which pre-run condition fired:
+
+- **WTO trigger:** `RSRC=resource;MSG=message text`, where `resource` is the resource name from the trigger definition and `message text` is the console message that matched.
+- **DSN trigger:** `DSNx|DSNAME`, where `x` is the dataset event indicator and `DSNAME` is the fully qualified dataset name that matched.
+
+## Using feedback in events
+
+To match a z/OS Agent Feedback value in an OpCon event, select the feedback type by name and provide a string to compare. The string supports SQL-style pattern matching:
+
+- Use `%` as a multi-character wildcard
+- Use `_` as a single-character wildcard
+- Single quotes (`'`) are not allowed in the match string
+
+For complete event-definition steps, refer to [Events](../job-components/events.md).
+
+## Related topics
+
+- [Events](../job-components/events.md) — define event triggers based on Agent Feedback values
+- [z/OS Job Details](../job-types/zos.md) — configure z/OS jobs and step control
+- [Operations Machine Messages](Operations-Machine-Messages.md) — agent status messages displayed in Schedule Operations

--- a/sidebars.js
+++ b/sidebars.js
@@ -1079,6 +1079,7 @@ module.exports = {
         "reference/Operations-Machine-Messages",
         "reference/Operations-File-Transfer-Messages",
         "reference/Windows-System-Errors",
+        "reference/zos-agent-feedback",
         "Files/UI/Solution-Manager/Library/LicenseSupport/License-Support",
         "Files/UI/Solution-Manager/Library/CloudEventsTriggers/CloudEventsTriggers",
         "file-locations",


### PR DESCRIPTION
Enumerate the platform-specific z/OS Agent Feedback types (User Message, Step Completion, Trigger Messages) with descriptions and value formats, so Automation Engineers no longer need to search across zos.md, ZOS-Job-Details.md, and events.md for scattered details. The universal Job Status Description feedback type is intentionally omitted from per-platform pages.

Cross-link the new page from docs/job-types/zos.md, docs/Files/UI/.../ZOS-Job-Details.md, and docs/job-components/events.md, and register it in the Reference sidebar section.