### PR TITLE
Add Reporting Service link to index page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -108,6 +108,7 @@ OpCon (Operations Console Cross-Platform Scheduler) is an enterprise-wide, heter
   - [New Install](./installation/install.md)
   - [Upgrade](./installation/upgrade.md)
   - [Component Install](./installation/components.md)
+  - [Reporting Service](https://help.smatechnologies.com/opcon/core/reports/reporting-service)
 
 </div>
 


### PR DESCRIPTION
## Summary

Adds a **Reporting Service** link under **System Configuration** in the Administration menu section of the docs landing page (`docs/index.md`).

The link points to the external OpCon help URL:
`https://help.smatechnologies.com/opcon/core/reports/reporting-service`

## Change

```markdown
- [System Configuration](./administration/System-Configuration-Overview.md)
  - [New Install](./installation/install.md)
  - [Upgrade](./installation/upgrade.md)
  - [Component Install](./installation/components.md)
  - [Reporting Service](https://help.smatechnologies.com/opcon/core/reports/reporting-service)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)