### PR TITLE
ci: raise Node heap limit in deploy workflows

### DIFF
--- a/.github/workflows/deploy-21.1.yml
+++ b/.github/workflows/deploy-21.1.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: "--max-old-space-size=8192"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/deploy-21.2.yml
+++ b/.github/workflows/deploy-21.2.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: "--max-old-space-size=8192"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: "--max-old-space-size=8192"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2


### PR DESCRIPTION
## Problem

The `deploy-main` workflow failed on the push of #517 to `main` with:

```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```

([failed run](https://github.com/smatechnologies/opcon-docs/actions/runs/29936527548))

## Root cause

The Docusaurus **3.10.2** migration (#515) increased the build's memory footprint. That PR added `NODE_OPTIONS: --max-old-space-size=8192` to the PR-check workflow (`build.yml`), but **not** to the three deploy workflows, which each run `yarn build` on push. As a result, pushes to `main` and the release branches still exhaust the default Node heap during the build step.

## Fix

Add the same job-level `NODE_OPTIONS` setting to:

- `.github/workflows/deploy-main.yml`
- `.github/workflows/deploy-21.1.yml`
- `.github/workflows/deploy-21.2.yml`

8192 MB matches `build.yml` and is well within the 16 GB available on `ubuntu-latest` runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)