### PR TITLE
Clarify self-contained .NET runtimes in system requirements

### DIFF
--- a/docs/installation/system-requirements.md
+++ b/docs/installation/system-requirements.md
@@ -8,7 +8,7 @@ tags:
   - Procedural
   - System Administrator
   - Installation
-last_updated: 2026-03-18
+last_updated: 2026-08-19
 doc_type: procedural
 ---
 
@@ -60,13 +60,13 @@ The following requirements apply to all Windows-based installations:
 | Component | Requirement |
 | - | - |
 | Operating system | Microsoft-supported Windows Server versions* |
-| .NET Core Runtime | .NET 10 Runtime and ASP.NET Core 10 Runtime |
-| .NET Framework Runtime |  .NET Framework 4.5 or greater |
+| .NET Core Runtime | .NET 10 Runtime and ASP.NET Core 10 Runtime, packaged with OpCon as self-contained assemblies. No separate installation on the OpCon server is required |
+| .NET Framework Runtime | .NET Framework 4.5 or greater, packaged with OpCon as self-contained assemblies |
 
 *New releases are fully tested once open to the general public for 6 months or more. Installing before the 6-month mark is at your own risk.
 
 :::note
-**SMA OpCon Install** is packaged with the .NET Core and .NET Framework requirements and will prompt to install them if not found on the server.
+SAM, the REST API, and supporting applications included in the **SMA OpCon** install are self-contained assemblies that include the .NET Core and .NET Framework runtimes they require. .NET Core is no longer required to be installed on the OpCon server. Maintenance releases apply patches to the .NET Core version the programs are packaged with to keep the software up to date.
 :::
 
 ## Database Requirements

--- a/versioned_docs/version-22.0/installation/system-requirements.md
+++ b/versioned_docs/version-22.0/installation/system-requirements.md
@@ -39,11 +39,11 @@ The following requirements apply to all Windows-based installations:
 | Component | Requirement |
 | - | - |
 | Operating system | Windows Server 2012 R2 or greater |
-| .NET Core Runtime | .NET Core & ASP .NET Core 3.0 Runtime or greater |
-| .NET Framework Runtime |  .NET Framework 4.5 or greater |
+| .NET Core Runtime | .NET Core & ASP .NET Core 3.0 Runtime or greater, packaged with OpCon as self-contained assemblies. No separate installation on the OpCon server is required |
+| .NET Framework Runtime | .NET Framework 4.5 or greater, packaged with OpCon as self-contained assemblies |
 
 :::note
-The **SMA OpCon Install** comes packaged with the .NET Core and .NET Framework requirements and will prompt to install them if they are not found on the server.
+SAM, the REST API, and supporting applications included in the **SMA OpCon** install are self-contained assemblies that include the .NET Core and .NET Framework runtimes they require. .NET Core is no longer required to be installed on the OpCon server. Maintenance releases apply patches to the .NET Core version the programs are packaged with to keep the software up to date.
 :::
 
 ## Database Requirements

--- a/versioned_docs/version-23.0/installation/system-requirements.md
+++ b/versioned_docs/version-23.0/installation/system-requirements.md
@@ -39,11 +39,11 @@ The following requirements apply to all Windows-based installations:
 | Component | Requirement |
 | - | - |
 | Operating system | Windows Server 2012 R2 or greater |
-| .NET Core Runtime | .NET Core & ASP .NET Core 3.0 Runtime or greater |
-| .NET Framework Runtime |  .NET Framework 4.5 or greater |
+| .NET Core Runtime | .NET Core & ASP .NET Core 3.0 Runtime or greater, packaged with OpCon as self-contained assemblies. No separate installation on the OpCon server is required |
+| .NET Framework Runtime | .NET Framework 4.5 or greater, packaged with OpCon as self-contained assemblies |
 
 :::note
-The **SMA OpCon Install** comes packaged with the .NET Core and .NET Framework requirements and will prompt to install them if they are not found on the server.
+SAM, the REST API, and supporting applications included in the **SMA OpCon** install are self-contained assemblies that include the .NET Core and .NET Framework runtimes they require. .NET Core is no longer required to be installed on the OpCon server. Maintenance releases apply patches to the .NET Core version the programs are packaged with to keep the software up to date.
 :::
 
 ## Database Requirements

--- a/versioned_docs/version-25.0/installation/system-requirements.md
+++ b/versioned_docs/version-25.0/installation/system-requirements.md
@@ -39,12 +39,13 @@ The following requirements apply to all Windows-based installations:
 | Component | Requirement |
 | - | - |
 | Operating system | Microsoft-supported Windows Server versions* |
-| .NET Core Runtime | .NET Core & ASP .NET Core 3.0 Runtime or greater |
-| .NET Framework Runtime |  .NET Framework 4.5 or greater |
+| .NET Core Runtime | .NET Core & ASP .NET Core 3.0 Runtime or greater, packaged with OpCon as self-contained assemblies. No separate installation on the OpCon server is required |
+| .NET Framework Runtime | .NET Framework 4.5 or greater, packaged with OpCon as self-contained assemblies |
+
 *New releases are considered fully tested once they have been open to the general public for 6 months or more. Any installation before the 6 month-mark is at your own risk.
 
 :::note
-The **SMA OpCon Install** comes packaged with the .NET Core and .NET Framework requirements and will prompt to install them if they are not found on the server.
+SAM, the REST API, and supporting applications included in the **SMA OpCon** install are self-contained assemblies that include the .NET Core and .NET Framework runtimes they require. .NET Core is no longer required to be installed on the OpCon server. Maintenance releases apply patches to the .NET Core version the programs are packaged with to keep the software up to date.
 :::
 
 ## Database Requirements

--- a/versioned_docs/version-26.0/installation/system-requirements.md
+++ b/versioned_docs/version-26.0/installation/system-requirements.md
@@ -8,7 +8,7 @@ tags:
   - Procedural
   - System Administrator
   - Installation
-last_updated: 2026-03-18
+last_updated: 2026-08-19
 doc_type: procedural
 ---
 
@@ -60,13 +60,13 @@ The following requirements apply to all Windows-based installations:
 | Component | Requirement |
 | - | - |
 | Operating system | Microsoft-supported Windows Server versions* |
-| .NET Core Runtime | .NET 10 Runtime and ASP.NET Core 10 Runtime |
-| .NET Framework Runtime |  .NET Framework 4.5 or greater |
+| .NET Core Runtime | .NET 10 Runtime and ASP.NET Core 10 Runtime, packaged with OpCon as self-contained assemblies. No separate installation on the OpCon server is required |
+| .NET Framework Runtime | .NET Framework 4.5 or greater, packaged with OpCon as self-contained assemblies |
 
 *New releases are fully tested once open to the general public for 6 months or more. Installing before the 6-month mark is at your own risk.
 
 :::note
-**SMA OpCon Install** is packaged with the .NET Core and .NET Framework requirements and will prompt to install them if not found on the server.
+SAM, the REST API, and supporting applications included in the **SMA OpCon** install are self-contained assemblies that include the .NET Core and .NET Framework runtimes they require. .NET Core is no longer required to be installed on the OpCon server. Maintenance releases apply patches to the .NET Core version the programs are packaged with to keep the software up to date.
 :::
 
 ## Database Requirements


### PR DESCRIPTION
## Summary

Updates the **Software requirements** section on the System Requirements page across all documentation versions (current, 26.0, 25.0, 23.0, 22.0) to delineate that the .NET Core and .NET Framework runtimes ship with OpCon as self-contained assemblies.

Key points now stated on each page:

- .NET Core is **no longer required to be installed** on the OpCon server
- The runtimes are packaged with OpCon as self-contained assemblies
- Maintenance releases apply patches to the packaged .NET Core version to keep the software up to date

## Changes

- Table rows for **.NET Core Runtime** and **.NET Framework Runtime** now note that each runtime is packaged with OpCon as self-contained assemblies. Each version's own runtime versions are preserved (.NET 10 / ASP.NET Core 10 for current and 26.0; .NET Core 3.0 or greater for 25.0, 23.0, and 22.0).
- Replaced the obsolete note stating that **SMA OpCon Install** "will prompt to install them if they are not found on the server." The new note wording matches the existing **Self-Contained .NET Core** entry in `whats-new.md`.
- Bumped `last_updated` on the two pages that carry front matter.
- Added a missing blank line before the footnote in the 25.0 page so the `*New releases...*` note renders as its own paragraph rather than joining the table.

## Open question for review

The repo's own `docs/installation/whats-new.md` scopes the self-contained change to **.NET Core only**, and .NET Framework is an OS-level component that cannot normally ship inside an assembly. The .NET Framework row was written as self-contained per the requested change — please confirm, or the row can be reverted to a plain "4.5 or greater" prerequisite.

## Related pages not touched

These still state the old prerequisite and may need a follow-up sweep:

- `installation/components.md` — "Any supported version of Windows with Microsoft .NET Framework 4.5.2 installed" (all versions)
- `utilities/Command-line-Utilities/SMADirectory.md` and `SMAHoliday.md` — list .NET Framework 4.5 as a prerequisite. These may be genuinely correct if those utilities remain .NET Framework-based.

## Test plan

- [ ] `yarn build` succeeds with no broken links or MDX errors
- [ ] Software requirements table and note render correctly on the current and all four versioned System Requirements pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)